### PR TITLE
Add optional "Output" field

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ struct CdbEntry {
     directory: String,
     file: String,
     command: String,
+    output: Option<String>,
 }
 
 enum Language {


### PR DESCRIPTION
Newer CMake versions seem to emit an "output" field per file which the tool does not accept, thanks to deny-unknown-fields.

Fixes #1